### PR TITLE
remove go toolchain directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/cockroachdb/cockroachdb-parser
 
-go 1.21.1
-
-toolchain go1.21.3
+go 1.21
 
 require (
 	github.com/bazelbuild/rules_go v0.46.0


### PR DESCRIPTION
This commit removes the go toolchain directive and keeps the go version consistent at 1.21