### PR TITLE
parser: remove gosigar package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/cockroachdb/version v0.0.0-20250314144055-3860cd14adf2
 	github.com/dave/dst v0.27.2
 	github.com/dustin/go-humanize v1.0.0
-	github.com/elastic/gosigar v0.14.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/geo v0.0.0-20210211234256-740aa86cb551
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,6 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/uo=
-github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -562,7 +560,6 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
 golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/sys v0.0.0-20180810173357-98c5dad5d1a0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/patches/0006-remove-gosigar.patch
+++ b/patches/0006-remove-gosigar.patch
@@ -1,0 +1,47 @@
+diff --git a/pkg/util/debugutil/debugutil.go b/pkg/util/debugutil/debugutil.go
+index 4aedcb9..446868c 100644
+--- a/pkg/util/debugutil/debugutil.go
++++ b/pkg/util/debugutil/debugutil.go
+@@ -6,12 +6,8 @@
+ package debugutil
+ 
+ import (
+-	"os"
+-	"path/filepath"
+ 	"runtime/debug"
+ 	"sync/atomic"
+-
+-	"github.com/elastic/gosigar"
+ )
+ 
+ // IsLaunchedByDebugger returns true in cases where the delve debugger
+@@ -22,29 +18,6 @@ func IsLaunchedByDebugger() bool {
+ 
+ var isLaunchedByDebugger atomic.Bool
+ 
+-func init() {
+-	isLaunchedByDebugger.Store(func(maybeDelvePID int) bool {
+-		// We loop in case there were intermediary processes like the gopls
+-		// language server.
+-		for maybeDelvePID != 0 {
+-			var exe gosigar.ProcExe
+-			if err := exe.Get(maybeDelvePID); err != nil {
+-				break
+-			}
+-			switch filepath.Base(exe.Name) {
+-			case "dlv":
+-				return true
+-			}
+-			var state gosigar.ProcState
+-			if err := state.Get(maybeDelvePID); err != nil {
+-				break
+-			}
+-			maybeDelvePID = state.Ppid
+-		}
+-		return false
+-	}(os.Getppid()))
+-}
+-
+ // SafeStack is an alias for []byte that handles redaction. Use this type
+ // instead of []byte when you are sure that the stack trace does not contain
+ // sensitive information.

--- a/pkg/util/debugutil/debugutil.go
+++ b/pkg/util/debugutil/debugutil.go
@@ -6,12 +6,8 @@
 package debugutil
 
 import (
-	"os"
-	"path/filepath"
 	"runtime/debug"
 	"sync/atomic"
-
-	"github.com/elastic/gosigar"
 )
 
 // IsLaunchedByDebugger returns true in cases where the delve debugger
@@ -21,29 +17,6 @@ func IsLaunchedByDebugger() bool {
 }
 
 var isLaunchedByDebugger atomic.Bool
-
-func init() {
-	isLaunchedByDebugger.Store(func(maybeDelvePID int) bool {
-		// We loop in case there were intermediary processes like the gopls
-		// language server.
-		for maybeDelvePID != 0 {
-			var exe gosigar.ProcExe
-			if err := exe.Get(maybeDelvePID); err != nil {
-				break
-			}
-			switch filepath.Base(exe.Name) {
-			case "dlv":
-				return true
-			}
-			var state gosigar.ProcState
-			if err := state.Get(maybeDelvePID); err != nil {
-				break
-			}
-			maybeDelvePID = state.Ppid
-		}
-		return false
-	}(os.Getppid()))
-}
 
 // SafeStack is an alias for []byte that handles redaction. Use this type
 // instead of []byte when you are sure that the stack trace does not contain


### PR DESCRIPTION
This commit removes the reference to the gosigar package. It leads to build issues when building for MacOS and Windows due to some functions not existing, but MOLT builds for cross platform