### PR TITLE
fix: trim CRLF and whitespace from version.txt for cross-platform compatibility

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -71,7 +71,7 @@ func SeemsOfficial() bool {
 }
 
 func parseCockroachVersion(versionTxt string) *version.Version {
-	txt := strings.TrimSuffix(versionTxt, "\n")
+	txt := strings.TrimSpace(versionTxt)
 	v, err := version.Parse(txt)
 	if err != nil {
 		panic(fmt.Errorf("could not parse version.txt: %w", err))


### PR DESCRIPTION
Replaces TrimSuffix with TrimSpace in parseCockroachVersion to correctly handle Windows-style line endings (\r\n) and other trailing whitespace. This prevents version parsing errors when version.txt contains CRLF line endings.