### PR TITLE
Fix integer overflow on 32-bit architectures

### DIFF
--- a/pkg/sql/lexbase/encode.go
+++ b/pkg/sql/lexbase/encode.go
@@ -23,7 +23,7 @@ import (
 )
 
 // EncodeFlags influence the formatting of strings and identifiers.
-type EncodeFlags int
+type EncodeFlags int64
 
 // HasFlags tests whether the given flags are set.
 func (f EncodeFlags) HasFlags(subset EncodeFlags) bool {

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -22,7 +22,7 @@ import (
 )
 
 // FmtFlags carries options for the pretty-printer.
-type FmtFlags int
+type FmtFlags int64
 
 // HasFlags tests whether the given flags are all set.
 func (f FmtFlags) HasFlags(subset FmtFlags) bool {

--- a/pkg/util/tsearch/eval.go
+++ b/pkg/util/tsearch/eval.go
@@ -168,9 +168,9 @@ func (e *tsEvaluator) evalFollowedBy(
 		if lExhausted && rExhausted {
 			break
 		}
-		var lPos, rPos int
+		var lPos, rPos int64
 		if !lExhausted {
-			lPos = int(lPositions.positions[lIdx].position) + lOffset
+			lPos = int64(lPositions.positions[lIdx].position) + int64(lOffset)
 		} else {
 			// Quit unless we're outputting all of the RHS, which we will if we have
 			// a negative match on the LHS.
@@ -180,7 +180,7 @@ func (e *tsEvaluator) evalFollowedBy(
 			lPos = math.MaxInt64
 		}
 		if !rExhausted {
-			rPos = int(rPositions.positions[rIdx].position) + rOffset
+			rPos = int64(rPositions.positions[rIdx].position) + int64(rOffset)
 		} else {
 			// Quit unless we're outputting all of the LHS, which we will if we have
 			// a negative match on the RHS.


### PR DESCRIPTION
## Problem

On 32-bit architectures (such as OpenBSD ARM, Linux ARM, etc.), building the parser fails with integer overflow errors:

```
pkg/util/tsearch/eval.go:180:11: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in assignment (overflows)
pkg/sql/sem/tree/format.go:185:2: FmtFlags(lexbase.EncFirstFreeFlagBit) << iota (constant 2147483648 of int type FmtFlags) overflows int
```

The issue occurs because:
1. `int` type is 32-bit on 32-bit architectures
2. Variables declared as `int` cannot hold 64-bit values like `math.MaxInt64`
3. Bit shift operations that produce values > 32 bits overflow

## Solution

This PR changes the affected types from `int` to `int64`:

1. **pkg/util/tsearch/eval.go**: Changed `lPos` and `rPos` variables from `int` to `int64` to accommodate `math.MaxInt64`
2. **pkg/sql/lexbase/encode.go**: Changed `EncodeFlags` type from `int` to `int64` to support large bit shift operations
3. **pkg/sql/sem/tree/format.go**: Changed `FmtFlags` type from `int` to `int64` for the same reason

## Testing

Successfully built and tested on:
- `GOOS=openbsd GOARCH=arm` (32-bit)
- Standard 64-bit platforms (Linux amd64, Darwin arm64)

The changes are backward compatible since `int64` is a superset of `int` on all platforms.

## Impact

- Minimal performance impact (int64 operations are native on all modern CPUs)
- Enables builds on 32-bit architectures
- No API changes or breaking changes