### PR TITLE
ci: declare contents:read on go workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read` block. The CI job checks out the repo, sets up Go via `actions/setup-go`, and runs `go test` / `golangci-lint`. No GitHub API calls outside the checkout.

The runtime supply-chain threat that justifies the cap is CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) - a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued. Per-workflow caps bound the runtime authority of every action in the chain regardless of repo or org default, give drift protection if that default ever widens, and register with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
